### PR TITLE
Remove -mpower8-* as they are enabled by default on gcc and unrecognized by clang

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,7 +9,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.3.0
 ctng_gcc_activation_build_num:
-- '15'
+- '16'
 ctng_target_platform:
 - linux-64
 ctng_vendor:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -9,13 +9,13 @@ channel_sources:
 channel_targets:
 - conda-forge main
 ctng_binutils:
-- 2.33.1
+- 2.29.1
 ctng_cpu_arch:
 - aarch64
 ctng_gcc:
 - 7.3.0
 ctng_gcc_activation_build_num:
-- '15'
+- '16'
 ctng_target_platform:
 - linux-aarch64
 ctng_vendor:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -9,7 +9,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.2.0
 ctng_gcc_activation_build_num:
-- '15'
+- '16'
 ctng_target_platform:
 - linux-ppc64le
 ctng_vendor:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
 matrix:
   include:
     - env: CONFIG=linux_ppc64le_ UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
-      os: linux-ppc64le
+      os: linux
+      arch: ppc64le
 
 script:
   - export CI=travis

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Current build status
 <table><tr>
     <td>Travis</td>
     <td>
-      <a href="https://travis-ci.org/conda-forge/ctng-compiler-activation-feedstock">
-        <img alt="macOS" src="https://img.shields.io/travis/conda-forge/ctng-compiler-activation-feedstock/master.svg?label=macOS">
+      <a href="https://travis-ci.com/conda-forge/ctng-compiler-activation-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/ctng-compiler-activation-feedstock/master.svg?label=macOS">
       </a>
     </td>
   </tr><tr>
@@ -130,7 +130,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,7 @@ ctng_binutils:
   - 2.33.1  # [not aarch64]
   - 2.29.1  # [aarch64]
 ctng_gcc_activation_build_num:
-  - 15
+  - 16
 ctng_target_platform:
   - linux-64                # [linux64]
   - linux-32                # [linux32]
@@ -25,7 +25,7 @@ FINAL_CPPFLAGS:
 FINAL_CFLAGS:
   - -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe  # [linux64]
   - -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe                    # [linux32]
-  - -mcpu=power8 -mtune=power8 -mpower8-fusion -mpower8-vector -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe  # [ppc64le]
+  - -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe  # [ppc64le]
   - -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe  # [aarch64]
 FINAL_CXXFLAGS:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe  # [linux64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,8 @@ ctng_gcc:
   - 7.3.0  # [linux64 or linux32 or aarch64]
   - 8.2.0  # [ppc64le]
 ctng_binutils:
-  - 2.33.1
+  - 2.33.1  # [not aarch64]
+  - 2.29.1  # [aarch64]
 ctng_gcc_activation_build_num:
   - 15
 ctng_target_platform:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
