### PR TITLE
Remove LDFLAGS from gfortran activate/deactivate

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,7 +9,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.3.0
 ctng_gcc_activation_build_num:
-- '16'
+- '17'
 ctng_target_platform:
 - linux-64
 ctng_vendor:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -15,7 +15,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.3.0
 ctng_gcc_activation_build_num:
-- '16'
+- '17'
 ctng_target_platform:
 - linux-aarch64
 ctng_vendor:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -9,7 +9,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.2.0
 ctng_gcc_activation_build_num:
-- '16'
+- '17'
 ctng_target_platform:
 - linux-ppc64le
 ctng_vendor:

--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -85,10 +85,8 @@ function _tc_activation() {
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
   FFLAGS_USED="@FFLAGS@ -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
-  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
 else
   FFLAGS_USED="@FFLAGS@ -isystem ${CONDA_PREFIX}/include"
-  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
 fi
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -103,7 +101,6 @@ _tc_activation \
   gfortran f95 \
   "FFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
-  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,7 +6,7 @@ ctng_binutils:
   - 2.33.1  # [not aarch64]
   - 2.29.1  # [aarch64]
 ctng_gcc_activation_build_num:
-  - 16
+  - 17
 ctng_target_platform:
   - linux-64                # [linux64]
   - linux-32                # [linux32]

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -85,10 +85,8 @@ function _tc_activation() {
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
   FFLAGS_USED="@FFLAGS@ -isystem ${PREFIX}/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
-  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
 else
   FFLAGS_USED="@FFLAGS@ -isystem ${CONDA_PREFIX}/include"
-  LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
 fi
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
@@ -103,7 +101,6 @@ _tc_activation \
   gfortran f95 \
   "FFLAGS,${FFLAGS:-${FFLAGS_USED}}" \
   "FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED}}" \
-  "LDFLAGS,${LDFLAGS:-${LDFLAGS_USED}}" \
   "DEBUG_FFLAGS,${FFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
   "DEBUG_FORTRANFLAGS,${FORTRANFLAGS:-${FFLAGS_USED} @DEBUG_FFLAGS@}" \
 

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -108,11 +108,11 @@ _tc_activation \
 _tc_activation \
   deactivate host @CHOST@ @CHOST@- \
   "FC,${FC:-${GFORTRAN}}" \
-  "F77,${F77:-${GFORTRAN}}"
+  "F77,${F77:-${GFORTRAN}}" \
+  "F90,${F90:-${GFORTRAN}}"
 
 if [ $? -ne 0 ]; then
   echo "ERROR: $(_get_sourced_filename) failed, see above for details"
-#exit 1
 else
   if [ "${CONDA_BUILD:-0}" = "1" ]; then
     if [ -f /tmp/new-env-$$.txt ]; then


### PR DESCRIPTION
This PR fixes #16 by removing `LDFLAGS` from the fortran activate/deactivate script, leaving the c-compiler scripts to do the work for us..

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
