### PR TITLE
Make scripts (mostly) POSIX compat; add shellcheck

### DIFF
--- a/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc7.5.0ctng_target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc7.5.0ctng_target_platformlinux-64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.5.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc8.4.0ctng_target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc8.4.0ctng_target_platformlinux-64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.4.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc9.3.0ctng_target_platformlinux-64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.12ctng_gcc9.3.0ctng_target_platformlinux-64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 9.3.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-aarch64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.5.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.5.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-aarch64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.4.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.4.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-aarch64.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 9.3.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 9.3.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-aarch64.yaml
@@ -17,7 +17,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.5.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-aarch64.yaml
@@ -17,7 +17,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.4.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-aarch64.yaml
+++ b/.ci_support/linux_aarch64_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-aarch64.yaml
@@ -17,7 +17,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 9.3.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-aarch64
 ctng_target_platform_u:

--- a/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc7.5.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 7.5.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc8.4.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 8.4.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-ppc64le.yaml
+++ b/.ci_support/linux_ppc64le_conda_glibc_ver2.17ctng_gcc9.3.0ctng_target_platformlinux-ppc64le.yaml
@@ -13,7 +13,7 @@ ctng_cpu_arch:
 ctng_gcc:
 - 9.3.0
 ctng_gcc_activation_build_num:
-- '30'
+- '31'
 ctng_target_platform:
 - linux-ppc64le
 ctng_target_platform_u:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -6,8 +6,15 @@
 # benefit from the improvement.
 
 set -xeuo pipefail
-export PYTHONUNBUFFERED=1
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/feedstock_root}"
+source ${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh
+
+
+( endgroup "Start Docker" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+
+export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
@@ -18,8 +25,9 @@ conda-build:
  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
 
 CONDARC
+BUILD_CMD=build
 
-conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip ${GET_BOA:-} -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -30,6 +38,8 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
+( endgroup "Configuring conda" ) 2> /dev/null
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
@@ -37,17 +47,28 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda $BUILD_CMD "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
     validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
 
     if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
         upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
     fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
 fi
+
+( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Provide a unified interface for the different logging
+# utilities CI providers offer. If unavailable, provide
+# a compatible fallback (e.g. bare `echo xxxxxx`).
+
+function startgroup {
+    # Start a foldable group of log lines
+    # Pass a single argument, quoted
+    case ${CI:-} in
+        azure )
+            echo "##[group]$1";;
+        travis )
+            echo "$1"
+            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::group::$1";;
+        * )
+            echo "$1";;
+    esac
+} 2> /dev/null
+
+function endgroup {
+    # End a foldable group of log lines
+    # Pass a single argument, quoted
+
+    case ${CI:-} in
+        azure )
+            echo "##[endgroup]";;
+        travis )
+            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+        github_actions )
+            echo "::endgroup::";;
+    esac
+} 2> /dev/null

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -5,6 +5,10 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
+source .scripts/logging_utils.sh
+
+( startgroup "Configure Docker" ) 2> /dev/null
+
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
@@ -66,6 +70,10 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
+( endgroup "Configure Docker" ) 2> /dev/null
+
+( startgroup "Start Docker" ) 2> /dev/null
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
@@ -89,3 +97,6 @@ docker run ${DOCKER_RUN_ARGS} \
 
 # verify that the end of the script was reached
 test -f "$DONE_CANARY"
+
+# This closes the last group opened in `build_steps.sh`
+( endgroup "Final checks" ) 2> /dev/null

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2020, conda-forge contributors
+Copyright (c) 2015-2021, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Installing `ctng-compiler-activation` from the `conda-forge` channel can be achi
 
 ```
 conda config --add channels conda-forge
+conda config --set channel_priority strict
 ```
 
 Once the `conda-forge` channel has been enabled, `binutils_linux-64, binutils_linux-aarch64, binutils_linux-ppc64le, gcc_bootstrap_linux-64, gcc_bootstrap_linux-aarch64, gcc_bootstrap_linux-ppc64le, gcc_linux-64, gcc_linux-aarch64, gcc_linux-ppc64le, gfortran_linux-64, gfortran_linux-aarch64, gfortran_linux-ppc64le, gxx_linux-64, gxx_linux-aarch64, gxx_linux-ppc64le` can be installed with:
@@ -251,9 +252,9 @@ build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
  * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string).
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
  * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#build-number-and-string)
+   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
    back to 0.
 
 Feedstock Maintainers

--- a/recipe/activate-binutils.sh
+++ b/recipe/activate-binutils.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-.' 'A-ZX__')
+        thing=$(echo "${thing}" | tr 'a-z+-.' 'A-ZX__')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/activate-g++.sh
+++ b/recipe/activate-g++.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -147,6 +147,7 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
   _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
 fi
 
+# shellcheck disable=SC2050  # "constant" comparison due to templating
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=@LINUX_MACHINE@"
 fi
@@ -172,6 +173,7 @@ _tc_activation \
 
 unset _CMAKE_ARGS
 
+# shellcheck disable=SC2050  # "constant" comparison due to templating
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
 _tc_activation \
    activate @CHOST@- \

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,8 +56,8 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
@@ -63,6 +65,7 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
@@ -105,12 +108,12 @@ fi
 
 _CONDA_PYTHON_SYSCONFIGDATA_NAME_USED=${_CONDA_PYTHON_SYSCONFIGDATA_NAME:-@_CONDA_PYTHON_SYSCONFIGDATA_NAME@}
 if [ -n "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" ] && [ -n "${SYS_SYSROOT}" ]; then
-  if find "$(dirname $(dirname ${SYS_PYTHON}))/lib/"python* -type f -name "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}.py" -exec false {} +; then
+  if find "$(dirname "$(dirname "${SYS_PYTHON}")")/lib/"python* -type f -name "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}.py" -exec false {} +; then
     echo ""
     echo "WARNING: The Python interpreter at the following prefix:"
-    echo "         $(dirname $(dirname ${SYS_PYTHON}))"
+    echo "         $(dirname "$(dirname "${SYS_PYTHON}")")"
     echo "         .. is not able to handle sysconfigdata-based compilation for the host:"
-    echo "         ${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED//_sysconfigdata_/}"
+    echo "         $( printf %s "${_CONDA_PYTHON_SYSCONFIGDATA_NAME_USED}" | sed s/_sysconfigdata_//g )"
     echo ""
     echo "         We are not preventing things from continuing here, but *this* Python will not"
     echo "         be able to compile software for this host, and, depending on whether it has"
@@ -190,16 +193,16 @@ else
   fi
 
   # fix prompt for zsh
-  if [[ -n "${ZSH_NAME:-}" ]]; then
+  if [ -n "${ZSH_NAME:-}" ]; then
     autoload -Uz add-zsh-hook
 
     _conda_clang_precmd() {
-      HOST="${CONDA_BACKUP_HOST}"
+      export HOST="${CONDA_BACKUP_HOST}"
     }
     add-zsh-hook -Uz precmd _conda_clang_precmd
 
     _conda_clang_preexec() {
-      HOST="${CONDA_TOOLCHAIN_HOST}"
+      export HOST="${CONDA_TOOLCHAIN_HOST}"
     }
     add-zsh-hook -Uz preexec _conda_clang_preexec
   fi

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -199,12 +199,14 @@ else
     autoload -Uz add-zsh-hook
 
     _conda_clang_precmd() {
-      export HOST="${CONDA_BACKUP_HOST}"
+      # shellcheck disable=SC2050,SC2034
+      HOST="${CONDA_BACKUP_HOST}"
     }
     add-zsh-hook -Uz precmd _conda_clang_precmd
 
     _conda_clang_preexec() {
-      export HOST="${CONDA_TOOLCHAIN_HOST}"
+      # shellcheck disable=SC2050,SC2034
+      HOST="${CONDA_TOOLCHAIN_HOST}"
     }
     add-zsh-hook -Uz preexec _conda_clang_preexec
   fi

--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,4 @@
+#! /usr/bin/env bash
 
 CBUILD=$(${PREFIX}/bin/*-gcc -dumpmachine)
 CHOST=${ctng_cpu_arch}-${ctng_vendor}-linux-gnu
@@ -38,3 +39,8 @@ find . -name "*activate*.sh" -exec sed -i.bak "s|@_CONDA_PYTHON_SYSCONFIGDATA_NA
 find . -name "*activate*.sh" -exec sed -i.bak "s|@CONDA_BUILD_CROSS_COMPILATION@|${CONDA_BUILD_CROSS_COMPILATION}|g"                "{}" \;
 
 find . -name "*activate*.sh.bak" -exec rm "{}" \;
+
+# Check if (de-)activate scripts can be used in non-Bash shells (ignoring the commonly supported "local" keyword.)
+find . -name "*activate*.sh" -exec shellcheck --severity=info --format=gcc {} \; \
+    | grep -vF "In POSIX sh, 'local' is undefined. [SC2039]" \
+    && exit 1 || true

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,7 +10,7 @@ libgfortran_soname:
 ctng_binutils:
   - 2.35
 ctng_gcc_activation_build_num:
-  - 30
+  - 31
 ctng_target_platform:
   - linux-64
   - linux-ppc64le

--- a/recipe/deactivate-binutils.sh
+++ b/recipe/deactivate-binutils.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-.' 'A-ZX__')
+        thing=$(echo "${thing}" | tr 'a-z+-.' 'A-ZX__')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/deactivate-g++.sh
+++ b/recipe/deactivate-g++.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -105,6 +105,7 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
   env > /tmp/old-env-$$.txt
 fi
 
+# shellcheck disable=SC2050  # "constant" comparison due to templating
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
 _tc_activation \
   deactivate @CHOST@- \

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,8 +56,8 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
@@ -63,6 +65,7 @@ function _tc_activation() {
       esac
       if [ "${pass}" = "apply" ]; then
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else
@@ -142,8 +145,10 @@ else
   fi
 
   # unfix prompt for zsh
-  if [[ -n "${ZSH_NAME:-}" ]]; then
+  if [ -n "${ZSH_NAME:-}" ]; then
+    # shellcheck disable=SC2039,SC2206
     precmd_functions=(${precmd_functions:#_conda_clang_precmd})
+    # shellcheck disable=SC2039,SC2206
     preexec_functions=(${preexec_functions:#_conda_clang_preexec})
   fi
 fi

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+# shellcheck shell=sh
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
-    if [ -n "${BASH_SOURCE[0]}" ]; then
+_get_sourced_filename() {
+    # shellcheck disable=SC2039  # non-POSIX array access is guarded
+    if [ -n "${BASH_SOURCE+x}" ] && [ -n "${BASH_SOURCE[0]}" ]; then
+        # shellcheck disable=SC2039  # non-POSIX array access is guarded
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
         # in zsh use prompt-style expansion to introspect the same information
@@ -28,7 +30,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing
@@ -54,15 +56,16 @@ function _tc_activation() {
           ;;
         *)
           newval="${CONDA_PREFIX}/bin/${tc_prefix}${thing}"
-          if [ ! -x "${newval}" -a "${pass}" = "check" ]; then
+          if [ ! -x "${newval}" ] && [ "${pass}" = "check" ]; then
             echo "ERROR: This cross-compiler package contains no program ${newval}"
             return 1
           fi
           ;;
       esac
       if [ "${pass}" = "apply" ]; then
-        thing=$(echo ${thing} | tr 'a-z+-' 'A-ZX_')
+        thing=$(echo "${thing}" | tr 'a-z+-' 'A-ZX_')
         eval oldval="\$${from}$thing"
+        # shellcheck disable=SC2154  # oldval is set via eval above
         if [ -n "${oldval}" ]; then
           eval export "${to}'${thing}'=\"${oldval}\""
         else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   build:
     # this dep is for us to be able to use gcc -dumpmachine to get the CBUILD value
     - gcc_impl_{{ target_platform }}
-    - shellcheck
+    - shellcheck  # [not (aarch64 or ppc64le)]
 
 outputs:
   - name: gcc_{{ ctng_target_platform }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
   build:
     # this dep is for us to be able to use gcc -dumpmachine to get the CBUILD value
     - gcc_impl_{{ target_platform }}
+    - shellcheck
 
 outputs:
   - name: gcc_{{ ctng_target_platform }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The activation scripts cannot be run in non-Bash-compatible shells, e.g., when run through `/bin/sh`/`/bin/dash` on Debian.
This is an attempt to allow support those shells.

I did not yet test these changes.