### PR TITLE
Fix non-POSIX activation/deactivation scripts.

### DIFF
--- a/recipe/activate-binutils.sh
+++ b/recipe/activate-binutils.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/activate-g++.sh
+++ b/recipe/activate-g++.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -191,7 +191,7 @@ else
   fi
 
   # fix prompt for zsh
-  if [[ -n "${ZSH_NAME:-}" ]]; then
+  if [ -n "${ZSH_NAME:-}" ]; then
     autoload -Uz add-zsh-hook
 
     _conda_clang_precmd() {

--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/deactivate-binutils.sh
+++ b/recipe/deactivate-binutils.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/deactivate-g++.sh
+++ b/recipe/deactivate-g++.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -142,7 +142,7 @@ else
   fi
 
   # unfix prompt for zsh
-  if [[ -n "${ZSH_NAME:-}" ]]; then
+  if [ -n "${ZSH_NAME:-}" ]; then
     precmd_functions=(${precmd_functions:#_conda_clang_precmd})
     preexec_functions=(${preexec_functions:#_conda_clang_preexec})
   fi

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/deactivate-gfortran.sh
+++ b/recipe/deactivate-gfortran.sh
@@ -2,7 +2,7 @@
 
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
-function _get_sourced_filename() {
+_get_sourced_filename() {
     if [ -n "${BASH_SOURCE[0]}" ]; then
         basename "${BASH_SOURCE[0]}"
     elif [ -n "${(%):-%x}" ]; then
@@ -28,7 +28,7 @@ function _get_sourced_filename() {
 #  For deactivation, the distinction is irrelevant as in all
 #  cases NAME simply gets reset to CONDA_BACKUP_NAME.  It is
 #  a fatal error if a program is identified but not present.
-function _tc_activation() {
+_tc_activation() {
   local act_nature=$1; shift
   local tc_prefix=$1; shift
   local thing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: .
 
 build:
-  number: 2
+  number: 3
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
These scripts are sourced from the shell hook during conda activation, so they need to run under any shell supported by that hook.  The shebang line is ignored when a script is sourced and not executed with `exec()`.

In particular, these scripts fail under `dash`, which is the default `/bin/sh` under Ubuntu 20.04 LTS.