### PR TITLE
gfortran symlinks should depend on _impl, not activation

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ source:
   path: .
 
 build:
-  number: 8
+  number: 9
   skip: True  # [not linux]
 
 requirements:
@@ -166,7 +166,7 @@ outputs:
     build:
       skip: True  # [target_platform != ctng_target_platform]
     requirements:
-      - gfortran_{{ target_platform }} {{ ctng_gcc }}.*
+      - gfortran_impl_{{ target_platform }} {{ ctng_gcc }}.*
       - gcc {{ ctng_gcc }}.*
     run_exports:
       strong:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -167,6 +167,7 @@ outputs:
       skip: True  # [target_platform != ctng_target_platform]
     requirements:
       - gfortran_impl_{{ target_platform }} {{ ctng_gcc }}.*
+      - gcc_impl_{{ target_platform }} {{ ctng_gcc }}.*
       - gcc {{ ctng_gcc }}.*
     run_exports:
       strong:


### PR DESCRIPTION
this will now match behavior of gcc and gxx

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
