### PR TITLE
Fix libstdcxx-ng and libgcc-ng version constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,5 @@
+{% set min_runtime_version={{ min_runtime_version }} %}
+
 package:
   name: ctng-compiler-activation
   version: {{ ctng_gcc }}
@@ -6,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 9
+  number: 10
   skip: True  # [not linux]
 
 requirements:
@@ -28,7 +30,7 @@ outputs:
         - sysroot_{{ ctng_target_platform }}
     run_exports:
       strong:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     test:
       requires:
         - sysroot_{{ ctng_target_platform }} {{ conda_glibc_ver }}
@@ -57,7 +59,7 @@ outputs:
       - gcc_impl_{{ target_platform }} {{ ctng_gcc }}.*
     run_exports:
       strong:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     test:
       commands:
         - ${PREFIX}/bin/gcc -v
@@ -92,9 +94,10 @@ outputs:
         - test -d ${CONDA_BUILD_SYSROOT} || exit 1
     run_exports:
       strong:
-        - libstdcxx-ng >={{ ctng_gcc }}
+        # This should be a transitive dependency, but conda-build doesn't support those
+        - libstdcxx-ng >={{ min_runtime_version }}
         # Because transitive run_exports do not work:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     about:
       summary: GNU C++ Compiler (activation scripts)
       home: https://github.com/conda-forge/ctng-compiler-activation-feedstock
@@ -110,9 +113,9 @@ outputs:
       - gcc {{ ctng_gcc }}.*
     run_exports:
       strong:
-        - libstdcxx-ng >={{ ctng_gcc }}
+        - libstdcxx-ng >={{ min_runtime_version }}
         # Because transitive run_exports do not work:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     test:
       commands:
         - ${PREFIX}/bin/g++ -v
@@ -143,7 +146,7 @@ outputs:
         - libgfortran{{ libgfortran_soname }} >={{ ctng_gcc }}
         - libgfortran-ng
         # Because transitive run_exports do not work:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     test:
       requires:
         - cmake >=3.11  # [x86_64 or aarch64 or ppc64le]
@@ -175,7 +178,7 @@ outputs:
         - libgfortran{{ libgfortran_soname }} >={{ ctng_gcc }}
         - libgfortran-ng
         # Because transitive run_exports do not work:
-        - libgcc-ng >={{ ctng_gcc }}
+        - libgcc-ng >={{ min_runtime_version }}
     test:
       commands:
         - ${PREFIX}/bin/gfortran -v

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set min_runtime_version={{ min_runtime_version }} %}
+{% set min_runtime_version = 12 %}
 
 package:
   name: ctng-compiler-activation


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
