### PR TITLE
Fix separator in `CMAKE_PREFIX_PATH` 

### DIFF
--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -89,14 +89,14 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
   LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${PREFIX}/lib -Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
   CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
   DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
-  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+  CMAKE_PREFIX_PATH_USED="${PREFIX};${CONDA_PREFIX}/@CHOST@/sysroot/usr"
 else
   CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
   DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
   CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
   DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
   LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
-  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX};${CONDA_PREFIX}/@CHOST@/sysroot/usr"
 fi
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -88,14 +88,14 @@ if [ "${CONDA_BUILD:-0}" = "1" ]; then
   LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
   CPPFLAGS_USED="@CPPFLAGS@ -isystem ${PREFIX}/include"
   DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${PREFIX}/include"
-  CMAKE_PREFIX_PATH_USED="${PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+  CMAKE_PREFIX_PATH_USED="${PREFIX};${CONDA_PREFIX}/@CHOST@/sysroot/usr"
 else
   CFLAGS_USED="@CFLAGS@ -isystem ${CONDA_PREFIX}/include"
   DEBUG_CFLAGS_USED="@DEBUG_CFLAGS@ -isystem ${CONDA_PREFIX}/include"
   CPPFLAGS_USED="@CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
   DEBUG_CPPFLAGS_USED="@DEBUG_CPPFLAGS@ -isystem ${CONDA_PREFIX}/include"
   LDFLAGS_USED="@LDFLAGS@ -Wl,-rpath,${CONDA_PREFIX}/lib -Wl,-rpath-link,${CONDA_PREFIX}/lib -L${CONDA_PREFIX}/lib"
-  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX}:${CONDA_PREFIX}/@CHOST@/sysroot/usr"
+  CMAKE_PREFIX_PATH_USED="${CONDA_PREFIX};${CONDA_PREFIX}/@CHOST@/sysroot/usr"
 fi
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ source:
   path: .
 
 build:
-  number: 10
+  number: 11
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
@kkraus14 found this issue: the separator in `CMAKE_PREFIX_PATH` should be semi-colon, not colon.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
