### PR TITLE
fix build number for binutils

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,6 +6,7 @@ gcc_version:
 libgfortran_soname:
   - 5
 binutils_version:
+  # reset binutils_build_number if bumping this
   - 2.40
 cross_target_platform:
   - linux-64

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,3 @@
-{% set build_num = 0 %}
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high
 # as the compiler; however, wherever libstdcxx changes the default ABI version
@@ -13,6 +12,9 @@
 # https://github.com/gcc-mirror/gcc/commit/9e18a25331fa25c3907249fede65a02c6817b06e
 {% set last_symbol_bump = 12 %}
 {% set min_runtime_version = gcc_major if gcc_major|int > last_symbol_bump else last_symbol_bump %}
+
+{% set build_num = 0 %}
+{% set binutils_build_num = 10 %}
 
 {% if cross_target_platform is not defined %}
 {% set cross_target_platform = "linux-64" %}
@@ -245,6 +247,8 @@ outputs:
 
   - name: binutils_{{ cross_target_platform }}
     version: "{{ binutils_version }}"
+    build:
+      string: h{{ PKG_HASH }}_{{ binutils_build_num }}
     script: install-binutils.sh
     requirements:
       run:


### PR DESCRIPTION
I was diffing build environments in a build that started failing without any relevant changes, and saw
```diff
     binutils_impl_linux-64:               2.40-ha1999f0_7            conda-forge
-    binutils_linux-64:                    2.40-hb3c18ed_9            conda-forge
+    binutils_linux-64:                    2.40-hb3c18ed_0            conda-forge
```
meaning that a build 2 month ago pulled in `_9`, while today I got `_0` (and the `impl` package didn't change).

As it turns out #121 reset the build number to 0, because there was no separate build number for binutils. Introduce one so we keep incrementing the build number correctly until a new binutils version comes along.