### PR TITLE
add -I $PREFIX/include to FFLAGS

### DIFF
--- a/recipe/activate-gfortran.sh
+++ b/recipe/activate-gfortran.sh
@@ -85,9 +85,9 @@ _tc_activation() {
 # When people are using conda-build, assume that adding rpath during build, and pointing at
 #    the host env's includes and libs is helpful default behavior
 if [ "${CONDA_BUILD:-0}" = "1" ]; then
-  FFLAGS_USED="@FFLAGS@ -isystem ${PREFIX}@LIBRARY_PREFIX@/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
+  FFLAGS_USED="@FFLAGS@ -isystem ${PREFIX}@LIBRARY_PREFIX@/include -I ${CONDA_PREFIX}@LIBRARY_PREFIX@/include -fdebug-prefix-map=${SRC_DIR}=/usr/local/src/conda/${PKG_NAME}-${PKG_VERSION} -fdebug-prefix-map=${PREFIX}=/usr/local/src/conda-prefix"
 else
-  FFLAGS_USED="@FFLAGS@ -isystem ${CONDA_PREFIX}@LIBRARY_PREFIX@/include"
+  FFLAGS_USED="@FFLAGS@ -isystem ${CONDA_PREFIX}@LIBRARY_PREFIX@/include -I ${CONDA_PREFIX}@LIBRARY_PREFIX@/include"
 fi
 
 if [ "${CONDA_BUILD:-0}" = "1" ]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 5 %}
+{% set build_num = 6 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high


### PR DESCRIPTION
`gfortran -isystem` doesn't find fortran modules, and (in some cases, at least) appears to not find header files, either.

closes #124 
closes https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/57
