### PR TITLE
GCC v14.3.0; clean up cos6 leftovers

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,8 +12,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: linux_64_cross_target_platformlinux-64gcc_version14.2.0
+      linux_64_cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: linux_64_cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformlinux-64gcc_version15.1.0:
@@ -24,8 +24,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: linux_64_cross_target_platformlinux-aarch64gcc_version14.2.0
+      linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformlinux-aarch64gcc_version15.1.0:
@@ -36,8 +36,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: linux_64_cross_target_platformlinux-ppc64legcc_version14.2.0
+      linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformlinux-ppc64legcc_version15.1.0:
@@ -48,8 +48,8 @@ jobs:
         CONFIG: linux_64_cross_target_platformwin-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_cross_target_platformwin-64gcc_version14.2.0:
-        CONFIG: linux_64_cross_target_platformwin-64gcc_version14.2.0
+      linux_64_cross_target_platformwin-64gcc_version14.3.0:
+        CONFIG: linux_64_cross_target_platformwin-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_cross_target_platformwin-64gcc_version15.1.0:
@@ -60,8 +60,8 @@ jobs:
         CONFIG: linux_aarch64_cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: linux_aarch64_cross_target_platformlinux-64gcc_version14.2.0
+      linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cross_target_platformlinux-64gcc_version15.1.0:
@@ -72,8 +72,8 @@ jobs:
         CONFIG: linux_aarch64_cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.2.0
+      linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cross_target_platformlinux-aarch64gcc_version15.1.0:
@@ -84,8 +84,8 @@ jobs:
         CONFIG: linux_aarch64_cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.2.0
+      linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cross_target_platformlinux-ppc64legcc_version15.1.0:
@@ -96,8 +96,8 @@ jobs:
         CONFIG: linux_aarch64_cross_target_platformwin-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cross_target_platformwin-64gcc_version14.2.0:
-        CONFIG: linux_aarch64_cross_target_platformwin-64gcc_version14.2.0
+      linux_aarch64_cross_target_platformwin-64gcc_version14.3.0:
+        CONFIG: linux_aarch64_cross_target_platformwin-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_cross_target_platformwin-64gcc_version15.1.0:
@@ -108,8 +108,8 @@ jobs:
         CONFIG: linux_ppc64le_cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: linux_ppc64le_cross_target_platformlinux-64gcc_version14.2.0
+      linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_cross_target_platformlinux-64gcc_version15.1.0:
@@ -120,8 +120,8 @@ jobs:
         CONFIG: linux_ppc64le_cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.2.0
+      linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_cross_target_platformlinux-aarch64gcc_version15.1.0:
@@ -132,8 +132,8 @@ jobs:
         CONFIG: linux_ppc64le_cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.2.0
+      linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_cross_target_platformlinux-ppc64legcc_version15.1.0:
@@ -144,8 +144,8 @@ jobs:
         CONFIG: linux_ppc64le_cross_target_platformwin-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_cross_target_platformwin-64gcc_version14.2.0:
-        CONFIG: linux_ppc64le_cross_target_platformwin-64gcc_version14.2.0
+      linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0:
+        CONFIG: linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_cross_target_platformwin-64gcc_version15.1.0:
@@ -156,8 +156,8 @@ jobs:
         CONFIG: win_64_cross_target_platformwin-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      win_64_cross_target_platformwin-64gcc_version14.2.0:
-        CONFIG: win_64_cross_target_platformwin-64gcc_version14.2.0
+      win_64_cross_target_platformwin-64gcc_version14.3.0:
+        CONFIG: win_64_cross_target_platformwin-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       win_64_cross_target_platformwin-64gcc_version15.1.0:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,8 +11,8 @@ jobs:
       osx_64_clang_version18.1cross_target_platformlinux-64gcc_version13.3.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.2.0
+      osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version18.1cross_target_platformlinux-64gcc_version15.1.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-64gcc_version15.1.0
@@ -20,8 +20,8 @@ jobs:
       osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version13.3.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.2.0
+      osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version15.1.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version15.1.0
@@ -29,8 +29,8 @@ jobs:
       osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version13.3.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.2.0
+      osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version15.1.0:
         CONFIG: osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version15.1.0
@@ -38,8 +38,8 @@ jobs:
       osx_64_clang_version19.1cross_target_platformlinux-64gcc_version13.3.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.2.0
+      osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version19.1cross_target_platformlinux-64gcc_version15.1.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-64gcc_version15.1.0
@@ -47,8 +47,8 @@ jobs:
       osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version13.3.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.2.0
+      osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version15.1.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version15.1.0
@@ -56,8 +56,8 @@ jobs:
       osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version13.3.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.2.0
+      osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version15.1.0:
         CONFIG: osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version15.1.0
@@ -65,8 +65,8 @@ jobs:
       osx_64_clang_version20.1cross_target_platformlinux-64gcc_version13.3.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.2.0
+      osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version20.1cross_target_platformlinux-64gcc_version15.1.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-64gcc_version15.1.0
@@ -74,8 +74,8 @@ jobs:
       osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version13.3.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.2.0:
-        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.2.0
+      osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0:
+        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version15.1.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version15.1.0
@@ -83,8 +83,8 @@ jobs:
       osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version13.3.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version13.3.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.2.0:
-        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.2.0
+      osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0:
+        CONFIG: osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0
         UPLOAD_PACKAGES: 'True'
       osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version15.1.0:
         CONFIG: osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version15.1.0

--- a/.ci_support/linux_64_cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_64_cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -1,27 +1,33 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
 - '18.1'
+- '19.1'
+- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
-- linux-ppc64le
+- linux-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- linux-64
 triplet:
-- powerpc64le-conda-linux-gnu
+- x86_64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_64_cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -1,27 +1,33 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
+- '18.1'
+- '19.1'
 - '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
-- linux-64
+- linux-aarch64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- linux-64
 triplet:
-- x86_64-conda-linux-gnu
+- aarch64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -15,19 +15,19 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
-- linux-64
+- linux-ppc64le
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
 - linux-64
 triplet:
-- x86_64-conda-linux-gnu
+- powerpc64le-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_64_cross_target_platformwin-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformwin-64gcc_version14.3.0.yaml
@@ -21,7 +21,7 @@ cross_target_platform:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -1,25 +1,31 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
+- '18.1'
 - '19.1'
+- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- linux-aarch64
 triplet:
 - x86_64-conda-linux-gnu
 zip_keys:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -13,21 +13,21 @@ clang_version:
 - '19.1'
 - '20.1'
 cross_stdlib:
-- m2w64-sysroot
+- sysroot
 cross_stdlib_version:
-- '12'
+- '2.17'
 cross_target_platform:
-- win-64
+- linux-aarch64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 triplet:
-- x86_64-w64-mingw32
+- aarch64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -1,25 +1,33 @@
 binutils_version:
 - '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+clang_version:
+- '18.1'
+- '19.1'
+- '20.1'
 cross_stdlib:
-- m2w64-sysroot
+- sysroot
 cross_stdlib_version:
-- '12'
+- '2.17'
 cross_target_platform:
-- win-64
+- linux-ppc64le
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
-- win-64
+- linux-aarch64
 triplet:
-- x86_64-w64-mingw32
+- powerpc64le-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_aarch64_cross_target_platformwin-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformwin-64gcc_version14.3.0.yaml
@@ -13,21 +13,21 @@ clang_version:
 - '19.1'
 - '20.1'
 cross_stdlib:
-- sysroot
+- m2w64-sysroot
 cross_stdlib_version:
-- '2.17'
+- '12'
 cross_target_platform:
-- linux-aarch64
+- win-64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 triplet:
-- aarch64-conda-linux-gnu
+- x86_64-w64-mingw32
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -1,27 +1,33 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
+- '18.1'
+- '19.1'
 - '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
-- linux-aarch64
+- linux-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- linux-ppc64le
 triplet:
-- aarch64-conda-linux-gnu
+- x86_64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -15,7 +15,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 docker_image:

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -15,19 +15,19 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
-- linux-64
+- linux-aarch64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
 - linux-ppc64le
 triplet:
-- x86_64-conda-linux-gnu
+- aarch64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -1,12 +1,16 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
+c_stdlib:
+- sysroot
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
+- '18.1'
+- '19.1'
 - '20.1'
 cross_stdlib:
 - sysroot
@@ -14,12 +18,14 @@ cross_stdlib_version:
 - '2.17'
 cross_target_platform:
 - linux-ppc64le
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- linux-ppc64le
 triplet:
 - powerpc64le-conda-linux-gnu
 zip_keys:

--- a/.ci_support/linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0.yaml
@@ -13,21 +13,21 @@ clang_version:
 - '19.1'
 - '20.1'
 cross_stdlib:
-- sysroot
+- m2w64-sysroot
 cross_stdlib_version:
-- '2.17'
+- '12'
 cross_target_platform:
-- linux-ppc64le
+- win-64
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
+- 14.3.0
 libgfortran_soname:
 - '5'
 target_platform:
-- linux-64
+- linux-ppc64le
 triplet:
-- powerpc64le-conda-linux-gnu
+- x86_64-w64-mingw32
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -7,21 +7,21 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_version:
-- '19.1'
+- '18.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
-- linux-aarch64
+- linux-64
 gcc_version:
-- 14.2.0
+- 14.3.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
 triplet:
-- aarch64-conda-linux-gnu
+- x86_64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -1,33 +1,27 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
 - '18.1'
-- '19.1'
-- '20.1'
 cross_stdlib:
-- m2w64-sysroot
+- sysroot
 cross_stdlib_version:
-- '12'
+- '2.17'
 cross_target_platform:
-- win-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
-gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
-target_platform:
 - linux-aarch64
+gcc_version:
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
 triplet:
-- x86_64-w64-mingw32
+- aarch64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -1,31 +1,25 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
 - '18.1'
-- '19.1'
-- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
 - linux-ppc64le
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-aarch64
+- osx-64
 triplet:
 - powerpc64le-conda-linux-gnu
 zip_keys:

--- a/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -13,15 +13,15 @@ cross_stdlib:
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
-- linux-ppc64le
+- linux-64
 gcc_version:
-- 14.2.0
+- 14.3.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
 - osx-64
 triplet:
-- powerpc64le-conda-linux-gnu
+- x86_64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -1,31 +1,25 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
-- '18.1'
 - '19.1'
-- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
 - linux-aarch64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-64
+- osx-64
 triplet:
 - aarch64-conda-linux-gnu
 zip_keys:

--- a/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -1,33 +1,27 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
-- '18.1'
 - '19.1'
-- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
 - '2.17'
 cross_target_platform:
-- linux-aarch64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- linux-ppc64le
 gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-aarch64
+- osx-64
 triplet:
-- aarch64-conda-linux-gnu
+- powerpc64le-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version13.3.0.yaml
+++ b/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version13.3.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0.yaml
@@ -7,15 +7,15 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_version:
-- '18.1'
+- '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:
-- 14.2.0
+- 14.3.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version15.1.0.yaml
+++ b/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-64gcc_version15.1.0.yaml
@@ -11,7 +11,7 @@ clang_version:
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
 - linux-64
 gcc_version:

--- a/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0.yaml
@@ -1,33 +1,27 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
-- '18.1'
-- '19.1'
 - '20.1'
 cross_stdlib:
 - sysroot
 cross_stdlib_version:
-- '2.12'
+- '2.17'
 cross_target_platform:
-- linux-64
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
-gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
-target_platform:
 - linux-aarch64
+gcc_version:
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64
 triplet:
-- x86_64-conda-linux-gnu
+- aarch64-conda-linux-gnu
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
+++ b/.ci_support/osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0.yaml
@@ -1,16 +1,12 @@
-binutils_version:
-- '2.40'
-c_stdlib:
-- sysroot
-cdt_name:
-- conda
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 clang_version:
-- '18.1'
-- '19.1'
 - '20.1'
 cross_stdlib:
 - sysroot
@@ -18,14 +14,12 @@ cross_stdlib_version:
 - '2.17'
 cross_target_platform:
 - linux-ppc64le
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-libgfortran_soname:
-- '5'
+- 14.3.0
+macos_machine:
+- x86_64-apple-darwin13.4.0
 target_platform:
-- linux-ppc64le
+- osx-64
 triplet:
 - powerpc64le-conda-linux-gnu
 zip_keys:

--- a/.ci_support/win_64_cross_target_platformwin-64gcc_version14.3.0.yaml
+++ b/.ci_support/win_64_cross_target_platformwin-64gcc_version14.3.0.yaml
@@ -1,27 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.13'
-MACOSX_SDK_VERSION:
-- '10.13'
+binutils_version:
+- '2.40'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-clang_version:
-- '18.1'
 cross_stdlib:
-- sysroot
+- m2w64-sysroot
 cross_stdlib_version:
-- '2.17'
+- '12'
 cross_target_platform:
-- linux-aarch64
+- win-64
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gcc_version:
-- 14.2.0
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- 14.3.0
+libgfortran_soname:
+- '5'
 target_platform:
-- osx-64
+- win-64
 triplet:
-- aarch64-conda-linux-gnu
+- x86_64-w64-mingw32
 zip_keys:
 - - cross_target_platform
   - triplet

--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>linux_64_cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -311,10 +311,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -332,10 +332,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -353,10 +353,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformwin-64gcc_version14.2.0</td>
+              <td>linux_64_cross_target_platformwin-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformwin-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cross_target_platformwin-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -374,10 +374,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -395,10 +395,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -416,10 +416,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -437,10 +437,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformwin-64gcc_version14.2.0</td>
+              <td>linux_aarch64_cross_target_platformwin-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformwin-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cross_target_platformwin-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -458,10 +458,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -479,10 +479,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -500,10 +500,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -521,10 +521,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformwin-64gcc_version14.2.0</td>
+              <td>linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformwin-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_cross_target_platformwin-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -542,10 +542,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -563,10 +563,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -584,10 +584,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version18.1cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -605,10 +605,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -626,10 +626,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -647,10 +647,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version19.1cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -668,10 +668,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.2.0</td>
+              <td>osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -689,10 +689,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.2.0</td>
+              <td>osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-aarch64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -710,10 +710,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.2.0</td>
+              <td>osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_clang_version20.1cross_target_platformlinux-ppc64legcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -731,10 +731,10 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_cross_target_platformwin-64gcc_version14.2.0</td>
+              <td>win_64_cross_target_platformwin-64gcc_version14.3.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7960&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cross_target_platformwin-64gcc_version14.2.0" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ctng-compiler-activation-feedstock?branchName=main&jobName=win&configuration=win%20win_64_cross_target_platformwin-64gcc_version14.3.0" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -29,7 +29,7 @@ cross_stdlib:
   - sysroot
   - m2w64-sysroot
 cross_stdlib_version:
-  - 2.12
+  - 2.17
   - 2.17
   - 2.17
   - 2.17

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,3 @@
-# cos6-specific because of PYTHON_SYSCONFIGDATA_NAME below.  Would be nice to make that more generic if possible.
 gcc_version:
   - 15.1.0
   - 14.3.0
@@ -145,12 +144,10 @@ FINAL_DEBUG_FFLAGS_win_64:
   - -fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe
 
 FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_linux_64:
-  - _sysconfigdata_x86_64_conda_cos6_linux_gnu
-FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_linux_32:
-  - _sysconfigdata_i686_conda_cos6_linux_gnu
+  - _sysconfigdata_x86_64_conda_linux_gnu
 FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_linux_ppc64le:
-  - _sysconfigdata_powerpc64le_conda_cos7_linux_gnu
+  - _sysconfigdata_powerpc64le_conda_linux_gnu
 FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_linux_aarch64:
-  - _sysconfigdata_aarch64_conda_cos7_linux_gnu
+  - _sysconfigdata_aarch64_conda_linux_gnu
 FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_linux_s390x:
   - _sysconfigdata_s390x_conda_linux_gnu

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # cos6-specific because of PYTHON_SYSCONFIGDATA_NAME below.  Would be nice to make that more generic if possible.
 gcc_version:
   - 15.1.0
-  - 14.2.0
+  - 14.3.0
   - 13.3.0
 libgfortran_soname:
   - 5

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -51,8 +51,6 @@ FINAL_CPPFLAGS:
 
 FINAL_CFLAGS_linux_64:
   - -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
-FINAL_CFLAGS_linux_32:
-  - -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_CFLAGS_linux_ppc64le:
   - -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe
 FINAL_CFLAGS_linux_aarch64:
@@ -64,8 +62,6 @@ FINAL_CFLAGS_win_64:
 
 FINAL_CXXFLAGS_linux_64:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
-FINAL_CXXFLAGS_linux_32:
-  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_CXXFLAGS_linux_ppc64le:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe
 FINAL_CXXFLAGS_linux_aarch64:
@@ -77,8 +73,6 @@ FINAL_CXXFLAGS_win_64:
 
 FINAL_FFLAGS_linux_64:
   - -fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe
-FINAL_FFLAGS_linux_32:
-  - -fopenmp -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -pipe
 FINAL_FFLAGS_linux_ppc64le:
   - -fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe
 FINAL_FFLAGS_linux_aarch64:
@@ -89,8 +83,6 @@ FINAL_FFLAGS_win_64:
   - -fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe
 
 FINAL_LDFLAGS_linux_64:
-  - -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,--allow-shlib-undefined
-FINAL_LDFLAGS_linux_32:
   - -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,--allow-shlib-undefined
 FINAL_LDFLAGS_linux_ppc64le:
   - -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--allow-shlib-undefined
@@ -106,8 +98,6 @@ FINAL_DEBUG_CPPFLAGS:
 
 FINAL_DEBUG_CFLAGS_linux_64:
   - -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
-FINAL_DEBUG_CFLAGS_linux_32:
-  - -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CFLAGS_linux_ppc64le:
   - -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CFLAGS_linux_aarch64:
@@ -119,8 +109,6 @@ FINAL_DEBUG_CFLAGS_win_64:
 
 FINAL_DEBUG_CXXFLAGS_linux_64:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe
-FINAL_DEBUG_CXXFLAGS_linux_32:
-  - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CXXFLAGS_linux_ppc64le:
   - -fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe
 FINAL_DEBUG_CXXFLAGS_linux_aarch64:
@@ -132,8 +120,6 @@ FINAL_DEBUG_CXXFLAGS_win_64:
 
 FINAL_DEBUG_FFLAGS_linux_64:
   - -fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -ffunction-sections -pipe
-FINAL_DEBUG_FFLAGS_linux_32:
-  - -fopenmp -march=prescott -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -pipe
 FINAL_DEBUG_FFLAGS_linux_ppc64le:
   - -fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe
 FINAL_DEBUG_FFLAGS_linux_aarch64:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set build_num = 10 %}
+{% set build_num = 11 %}
 
 {% set gcc_major = 13 if gcc_version is undefined else gcc_version.split(".")[0] %}
 # generally, the runtime version of libstdcxx needs to be at least as high


### PR DESCRIPTION
Also updates `FINAL_CONDA_PYTHON_SYSCONFIGDATA_NAME_*`; we've been using the new names (without `_cos6` / `_cos7`) since about 5 years on the python feedstock already: https://github.com/conda-forge/python-feedstock/commit/db61f524cb9b8f5a9b53c1c543a5cef6f0d9ff88

Depends on https://github.com/conda-forge/ctng-compilers-feedstock/pull/177

Did a check for symbols changes in the [API docs](https://gcc.gnu.org/onlinedocs/libstdc++/manual/api.html), nothing stands out.

