### PR TITLE
make MESON_ARGS robust for feeding to meson-python

### DIFF
--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -146,7 +146,7 @@ if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ]; then
   if [ "@CMAKE_SYSTEM_NAME@" = "Darwin" ]; then
     _CMAKE_ARGS="${_CMAKE_ARGS} -DCMAKE_SYSTEM_VERSION=@UNAME_KERNEL_RELEASE@"
   fi
-  _MESON_ARGS="${_MESON_ARGS} --cross-file ${CONDA_PREFIX}@LIBRARY_PREFIX@/meson_cross_file.txt"
+  _MESON_ARGS="${_MESON_ARGS} --cross-file=${CONDA_PREFIX}@LIBRARY_PREFIX@/meson_cross_file.txt"
   echo "[host_machine]" > "${CONDA_PREFIX}@LIBRARY_PREFIX@/meson_cross_file.txt"
   echo "system = '@MESON_SYSTEM@'" >> "${CONDA_PREFIX}@LIBRARY_PREFIX@/meson_cross_file.txt"
   echo "cpu = '@MACHINE@'" >> "${CONDA_PREFIX}@LIBRARY_PREFIX@/meson_cross_file.txt"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_num: 16
+  build_num: 17
   gcc_version: ${{ gcc_version | default("13.1.0") }}
   gcc_major: ${{ (gcc_version | split("."))[0] | int }}
   default_skip: ${{ (target_platform == "win-64" and cross_target_platform != "win-64") or (cross_target_platform == "win-64" and gcc_major|int < 13) or cross_target_platform == "linux-s390x" or s390x or ((cross_target_platform in ("osx-64", "osx-arm64") or osx) and gcc_major|int < 15) }}


### PR DESCRIPTION
For feedstocks using `meson-python` (e.g. numpy, scipy etc.), we need to pass `MESON_ARGS` through a very particular interface; namely, each flag needs to be prepended with `-Csetup-args=`.

The simplest way to do this is `-Csetup-args=${MESON_ARGS// / -Csetup-args=}`, however this requires that each flag in the activation does not contain spaces. Currently, the activation here does `--cross-file ...` instead of `--crossfile=...`, which then gets transformed into the incorrect
```
-Csetup-args=--cross-file -Csetup-args=$BUILD_PREFIX/meson_cross_file.txt
```

Use an equal sign instead. Necessary for https://github.com/conda-forge/numpy-feedstock/pull/375