### PR TITLE
fix: add -fno-merge-constants to default GCC flags

### DIFF
--- a/recipe/build_scripts.sh
+++ b/recipe/build_scripts.sh
@@ -6,32 +6,36 @@ source $RECIPE_DIR/get_cpu_arch.sh
 
 FINAL_CPPFLAGS="-DNDEBUG -D_FORTIFY_SOURCE=2 -O2"
 
-FINAL_CFLAGS_linux_64="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
-FINAL_CFLAGS_linux_ppc64le="-mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CFLAGS_linux_aarch64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CFLAGS_linux_s390x="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CFLAGS_linux_riscv64="-march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CFLAGS_win_64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CFLAGS_osx_64="-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe"
-FINAL_CFLAGS_osx_arm64="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe"
+# -fno-merge-constants is needed because merging constants can corrupt string
+# constants that share storage with the conda prefix when binaries are
+# relocated at install time, see
+# https://github.com/conda-forge/ctng-compiler-activation-feedstock/issues/63
+FINAL_CFLAGS_linux_64="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O2 -ffunction-sections -pipe"
+FINAL_CFLAGS_linux_ppc64le="-mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CFLAGS_linux_aarch64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CFLAGS_linux_s390x="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CFLAGS_linux_riscv64="-march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CFLAGS_win_64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CFLAGS_osx_64="-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -fno-merge-constants -O2 -pipe"
+FINAL_CFLAGS_osx_arm64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-merge-constants -O2 -pipe"
 
-FINAL_CXXFLAGS_linux_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
-FINAL_CXXFLAGS_linux_ppc64le="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CXXFLAGS_linux_aarch64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CXXFLAGS_linux_s390x="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CXXFLAGS_linux_riscv64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CXXFLAGS_win_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_CXXFLAGS_osx_64="-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
-FINAL_CXXFLAGS_osx_arm64="-ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
+FINAL_CXXFLAGS_linux_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O2 -ffunction-sections -pipe"
+FINAL_CXXFLAGS_linux_ppc64le="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CXXFLAGS_linux_aarch64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CXXFLAGS_linux_s390x="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CXXFLAGS_linux_riscv64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CXXFLAGS_win_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_CXXFLAGS_osx_64="-march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -fno-merge-constants -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
+FINAL_CXXFLAGS_osx_arm64="-ftree-vectorize -fPIC -fstack-protector-strong -fno-merge-constants -O2 -pipe -stdlib=libc++ -fvisibility-inlines-hidden -fmessage-length=0"
 
-FINAL_FFLAGS_linux_64="-fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe"
-FINAL_FFLAGS_linux_ppc64le="-fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_FFLAGS_linux_aarch64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_FFLAGS_linux_s390x="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_FFLAGS_linux_riscv64="-fopenmp -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_FFLAGS_win_64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O3 -pipe"
-FINAL_FFLAGS_osx_64="-march=core2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector -O2 -pipe"
-FINAL_FFLAGS_osx_arm64="-march=armv8.3-a -ftree-vectorize -fPIC -fno-stack-protector -O2 -pipe"
+FINAL_FFLAGS_linux_64="-fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O2 -ffunction-sections -pipe"
+FINAL_FFLAGS_linux_ppc64le="-fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_FFLAGS_linux_aarch64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_FFLAGS_linux_s390x="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_FFLAGS_linux_riscv64="-fopenmp -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_FFLAGS_win_64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -fno-merge-constants -O3 -pipe"
+FINAL_FFLAGS_osx_64="-march=core2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector -fno-merge-constants -O2 -pipe"
+FINAL_FFLAGS_osx_arm64="-march=armv8.3-a -ftree-vectorize -fPIC -fno-stack-protector -fno-merge-constants -O2 -pipe"
 
 FINAL_LDFLAGS_linux_64="-Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,--allow-shlib-undefined"
 FINAL_LDFLAGS_linux_ppc64le="-Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--allow-shlib-undefined"
@@ -53,32 +57,32 @@ FINAL_LDFLAGS_LD_osx_arm64="-headerpad_max_install_names -dead_strip_dylibs"
 
 FINAL_DEBUG_CPPFLAGS="-D_DEBUG -D_FORTIFY_SOURCE=2 -Og"
 
-FINAL_DEBUG_CFLAGS_linux_64="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
-FINAL_DEBUG_CFLAGS_linux_ppc64le="-mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CFLAGS_linux_aarch64="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CFLAGS_linux_s390x="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CFLAGS_linux_riscv64="-march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CFLAGS_win_64="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CFLAGS_osx_64="-Og -g -Wall -Wextra"
-FINAL_DEBUG_CFLAGS_osx_arm64="-Og -g -Wall -Wextra"
+FINAL_DEBUG_CFLAGS_linux_64="-march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
+FINAL_DEBUG_CFLAGS_linux_ppc64le="-mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CFLAGS_linux_aarch64="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CFLAGS_linux_s390x="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CFLAGS_linux_riscv64="-march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CFLAGS_win_64="-ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CFLAGS_osx_64="-fno-merge-constants -Og -g -Wall -Wextra"
+FINAL_DEBUG_CFLAGS_osx_arm64="-fno-merge-constants -Og -g -Wall -Wextra"
 
-FINAL_DEBUG_CXXFLAGS_linux_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
-FINAL_DEBUG_CXXFLAGS_linux_ppc64le="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CXXFLAGS_linux_aarch64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CXXFLAGS_linux_s390x="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CXXFLAGS_linux_riscv64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CXXFLAGS_win_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_CXXFLAGS_osx_64="-Og -g -Wall -Wextra"
-FINAL_DEBUG_CXXFLAGS_osx_arm64="-Og -g -Wall -Wextra"
+FINAL_DEBUG_CXXFLAGS_linux_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -ffunction-sections -pipe"
+FINAL_DEBUG_CXXFLAGS_linux_ppc64le="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CXXFLAGS_linux_aarch64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CXXFLAGS_linux_s390x="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CXXFLAGS_linux_riscv64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CXXFLAGS_win_64="-fvisibility-inlines-hidden -std=c++17 -fmessage-length=0 -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_CXXFLAGS_osx_64="-fno-merge-constants -Og -g -Wall -Wextra"
+FINAL_DEBUG_CXXFLAGS_osx_arm64="-fno-merge-constants -Og -g -Wall -Wextra"
 
-FINAL_DEBUG_FFLAGS_linux_64="-fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -ffunction-sections -pipe"
-FINAL_DEBUG_FFLAGS_linux_ppc64le="-fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_FFLAGS_linux_aarch64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_FFLAGS_linux_s390x="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_FFLAGS_linux_riscv64="-fopenmp -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_FFLAGS_win_64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
-FINAL_DEBUG_FFLAGS_osx_64="-march=core2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector -O2 -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments"
-FINAL_DEBUG_FFLAGS_osx_arm64="-march=armv8.3-a -ftree-vectorize -fPIC -fno-stack-protector -O2 -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments"
+FINAL_DEBUG_FFLAGS_linux_64="-fopenmp -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-all -fno-plt -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments -ffunction-sections -pipe"
+FINAL_DEBUG_FFLAGS_linux_ppc64le="-fopenmp -mcpu=power8 -mtune=power8 -ftree-vectorize -fPIC -fstack-protector-strong -pipe -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_FFLAGS_linux_aarch64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_FFLAGS_linux_s390x="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_FFLAGS_linux_riscv64="-fopenmp -march=rv64imafdc -mabi=lp64d -ftree-vectorize -fPIC -fstack-protector-strong -pipe -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_FFLAGS_win_64="-fopenmp -ftree-vectorize -fPIC -fstack-protector-strong -pipe -fno-merge-constants -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fvar-tracking-assignments -pipe"
+FINAL_DEBUG_FFLAGS_osx_64="-march=core2 -mtune=haswell -ftree-vectorize -fPIC -fstack-protector -fno-merge-constants -O2 -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments"
+FINAL_DEBUG_FFLAGS_osx_arm64="-march=armv8.3-a -ftree-vectorize -fPIC -fno-stack-protector -fno-merge-constants -O2 -pipe -Og -g -Wall -Wextra -fcheck=all -fbacktrace -fimplicit-none -fvar-tracking-assignments"
 
 cross_target_platform_u=${cross_target_platform/-/_}
 
@@ -198,6 +202,10 @@ cp activate-gcc.sh activate-clang.sh
 cp activate-g++.sh activate-clang++.sh
 cp deactivate-gcc.sh deactivate-clang.sh
 cp deactivate-g++.sh deactivate-clang++.sh
+
+# clang does not support -fno-merge-constants (and does not perform the
+# problematic optimisation, see issue #63)
+sed -i.bak "s| -fno-merge-constants||g" activate-clang.sh activate-clang++.sh
 
 GCC_EXTRA=" \
 \"CC,\${CONDA_PREFIX}${LIBRARY_PREFIX}/bin/${CHOST}-cc\" \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_num: 25
+  build_num: 26
   gcc_version: ${{ gcc_version | default("13.1.0") }}
   gcc_major: ${{ (gcc_version | split("."))[0] | int }}
   default_skip: ${{ (target_platform == "win-64" and cross_target_platform != "win-64") or (cross_target_platform == "win-64" and gcc_major|int < 13) or cross_target_platform == "linux-s390x" or s390x or ((cross_target_platform in ("linux-riscv64", "osx-64", "osx-arm64") or osx) and gcc_major|int < 15) }}
@@ -79,6 +79,9 @@ outputs:
             then: ${CC} ${LDFLAGS} c_aligned.o -o c_aligned
           - if: target_platform == cross_target_platform
             then: ./c_aligned
+          # see issue 63
+          - echo "${CFLAGS}" | grep -q -- "-fno-merge-constants"
+          - echo "${DEBUG_CFLAGS}" | grep -q -- "-fno-merge-constants"
           # CONDA_BUILD_SYSROOT is defined for clang++ to find correct C++ headers, see issue 8
           - test -z "${CONDA_BUILD_SYSROOT+x}" && echo "CONDA_BUILD_SYSROOT is not set" && exit 1
           - test -d ${CONDA_BUILD_SYSROOT} || exit 1
@@ -157,6 +160,8 @@ outputs:
             then: ${CC} ${LDFLAGS} c_aligned.o -o c_aligned
           - if: target_platform == cross_target_platform
             then: ./c_aligned
+          # clang does not support -fno-merge-constants, see issue 63
+          - '! echo "${CFLAGS}" | grep -q -- "-fno-merge-constants"'
           # CONDA_BUILD_SYSROOT is defined for clang++ to find correct C++ headers, see issue 8
           - test -z "${CONDA_BUILD_SYSROOT+x}" && echo "CONDA_BUILD_SYSROOT is not set" && exit 1
           - test -d ${CONDA_BUILD_SYSROOT} || exit 1
@@ -218,6 +223,9 @@ outputs:
             then: ${CXX} ${LDFLAGS} cpp_aligned.o -o cpp_aligned
           - if: target_platform == cross_target_platform
             then: ./cpp_aligned
+          # see issue 63
+          - echo "${CXXFLAGS}" | grep -q -- "-fno-merge-constants"
+          - echo "${DEBUG_CXXFLAGS}" | grep -q -- "-fno-merge-constants"
           - test -z "${CONDA_BUILD_SYSROOT+x}" && echo "CONDA_BUILD_SYSROOT is not set" && exit 1
           - test -d ${CONDA_BUILD_SYSROOT} || exit 1
     about:
@@ -302,6 +310,8 @@ outputs:
             then: ${CXX} ${LDFLAGS} cpp_aligned.o -o cpp_aligned
           - if: target_platform == cross_target_platform
             then: ./cpp_aligned
+          # clang does not support -fno-merge-constants, see issue 63
+          - '! echo "${CXXFLAGS}" | grep -q -- "-fno-merge-constants"'
           - test -z "${CONDA_BUILD_SYSROOT+x}" && echo "CONDA_BUILD_SYSROOT is not set" && exit 1
           - test -d ${CONDA_BUILD_SYSROOT} || exit 1
     about:


### PR DESCRIPTION
GCC enables `-fmerge-constants` at `-O1` and above, which can merge an unrelated string literal into the tail of a constant containing the conda prefix. When conda relocates a binary it pads the prefix string with null bytes, silently corrupting the merged literal.

The flag is stripped from the clang activation scripts (which are copies of the gcc ones) since clang neither supports the flag nor performs the problematic optimisation.

Fixes #63

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
