### PR TITLE
Default linux-riscv64 C builds to GNU C17

### DIFF
--- a/recipe/build_scripts.sh
+++ b/recipe/build_scripts.sh
@@ -105,6 +105,14 @@ FINAL_LDFLAGS_LD="${!FINAL_LDFLAGS_LD}"
 
 MAJOR_VERSION="${PKG_VERSION%%.*}"
 
+# GCC 15 switched the default C dialect from gnu17 to gnu23. Keep the
+# linux-riscv64 bootstrap on the previous default until its dependency graph
+# has been made C23-compatible.
+if [[ "${cross_target_platform}" == "linux-riscv64" && "${MAJOR_VERSION}" -ge 15 ]]; then
+    FINAL_CFLAGS="${FINAL_CFLAGS} -std=gnu17"
+    FINAL_DEBUG_CFLAGS="${FINAL_DEBUG_CFLAGS} -std=gnu17"
+fi
+
 # See https://github.com/conda-forge/ctng-compiler-activation-feedstock/issues/42
 # -std=c++17 shouldn't be a default flag, but from gcc 11 onwards it is the default.
 # Not removing the flag for gcc 8, 9 because some package ABIs change according to

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_num: 0
+  build_num: 1
   gcc_version: ${{ gcc_version | default("16.1.0") }}
   gcc_major: ${{ (gcc_version | split("."))[0] | int }}
   default_skip: ${{ (target_platform == "win-64" and cross_target_platform != "win-64") or cross_target_platform == "linux-s390x" or s390x or ((cross_target_platform in ("linux-riscv64", "osx-64", "osx-arm64") or osx) and gcc_major|int < 15) or (riscv64 and gcc_major|int < 15) or (riscv64 and cross_target_platform in ("osx-64", "osx-arm64")) }}
@@ -82,6 +82,10 @@ outputs:
           # see issue 63
           - echo "${CFLAGS}" | grep -q -- "-fno-merge-constants"
           - echo "${DEBUG_CFLAGS}" | grep -q -- "-fno-merge-constants"
+          - if: cross_target_platform == "linux-riscv64" and gcc_major >= 15
+            then: echo "${CFLAGS}" | grep -q -- "-std=gnu17"
+          - if: cross_target_platform == "linux-riscv64" and gcc_major >= 15
+            then: echo "${DEBUG_CFLAGS}" | grep -q -- "-std=gnu17"
           # CONDA_BUILD_SYSROOT is defined for clang++ to find correct C++ headers, see issue 8
           - test -z "${CONDA_BUILD_SYSROOT+x}" && echo "CONDA_BUILD_SYSROOT is not set" && exit 1
           - test -d ${CONDA_BUILD_SYSROOT} || exit 1


### PR DESCRIPTION
## Summary

- append `-std=gnu17` to release and debug C flags for `linux-riscv64` when using GCC 15 or newer
- add activation-package tests for both `CFLAGS` and `DEBUG_CFLAGS`
- bump the feedstock build number from 0 to 1

## Motivation

GCC 15 changed its default C dialect from GNU C17 to GNU C23. During the
linux-riscv64 bootstrap this breaks older, foundational sources before their
dependency graph can be built. Two current examples are:

- conda-forge/gmp-feedstock#42, whose configure probe relies on the pre-C23
  meaning of an empty parameter list
- conda-forge/pkg-config-feedstock#47, whose bundled GLib uses `bool` as an
  identifier

Keeping the riscv64 bootstrap on the previous GCC default provides one central
compatibility layer while those feedstocks and their upstreams are made
C23-compatible. The flag is restricted to `linux-riscv64` and GCC 15+; other
platforms and GCC 14 remain unchanged. Recipe-provided C flags are appended
after the activation defaults, so projects can still explicitly select a newer
C dialect.

This is fundamentally an issue with the default C language standard. Could we
consider adding this C flag globally for linux-riscv64, as proposed here, to
avoid having to patch a large number of individual feedstocks?
