### PR TITLE
gfortran_osx-arm64 should rely on clang_osx-arm64

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_num: 0
+  build_num: 1
   gcc_version: ${{ gcc_version | default("16.1.0") }}
   gcc_major: ${{ (gcc_version | split("."))[0] | int }}
   default_skip: ${{ (target_platform == "win-64" and cross_target_platform != "win-64") or cross_target_platform == "linux-s390x" or s390x or ((cross_target_platform in ("linux-riscv64", "osx-64", "osx-arm64") or osx) and gcc_major|int < 15) or (riscv64 and gcc_major|int < 15) or (riscv64 and cross_target_platform in ("osx-64", "osx-arm64")) }}
@@ -332,16 +332,18 @@ outputs:
       run:
         - gfortran_impl_${{ cross_target_platform }} ${{ gcc_version }}.*
         - gfortran_impl_${{ target_platform }} ${{ gcc_version }}.*
-        # for activation of gcc env vars:
-        - ${{ pin_subpackage("gcc_" ~ cross_target_platform, exact=True) }}
-        # for activation of binutils env vars:
-        - if: cross_target_platform not in ("osx-64", "osx-arm64")
-          then: binutils_${{ cross_target_platform }}
-          else: cctools_${{ cross_target_platform }}
+        # for activation of gcc and binutils env vars:
+        - if: cross_target_platform in ("osx-64", "osx-arm64")
+          then:
+            - clang_${{ cross_target_platform }}
+            - cctools_${{ cross_target_platform }}
+            - if: osx
+              then: sdkroot_env_${{ cross_target_platform }}
+          else:
+            - ${{ pin_subpackage("gcc_" ~ cross_target_platform, exact=True) }}
+            - binutils_${{ cross_target_platform }}
         - if: cross_stdlib != "None"
           then: ${{ cross_stdlib }}_${{ cross_target_platform }}
-        - if: osx and cross_target_platform in ("osx-64", "osx-arm64")
-          then: sdkroot_env_${{ cross_target_platform }}
       run_exports:
         strong:
           - libgfortran${{ libgfortran_soname }} >=${{ gcc_version }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -352,22 +352,24 @@ outputs:
           - if: cross_target_platform == "win-64"
             then: ucrt >=10.0.20348.0
     tests:
-      - files:
-          recipe:
-            - tests/fortomp/*
-        requirements:
-          run:
-            - if: x86_64 or aarch64 or ppc64le
-              then: cmake >=3.11
-            - if: x86_64 or aarch64 or ppc64le
-              then: make
-            - if: cross_stdlib != "None"
-              then: ${{ cross_stdlib }}_${{ cross_target_platform }} ${{ cross_stdlib_version }}.*
-        script:
-          - ${FC} --version
-          - pushd tests/fortomp
-          - if: target_platform == cross_target_platform and (x86_64 or aarch64 or ppc64le)
-            then: sh test_fort.sh
+      - if: linux and cross_target_platform not in ("osx-64", "osx-arm64"):
+        then:
+          files:
+            recipe:
+              - tests/fortomp/*
+          requirements:
+            run:
+              - if: x86_64 or aarch64 or ppc64le
+                then: cmake >=3.11
+              - if: x86_64 or aarch64 or ppc64le
+                then: make
+              - if: cross_stdlib != "None"
+                then: ${{ cross_stdlib }}_${{ cross_target_platform }} ${{ cross_stdlib_version }}.*
+          script:
+            - ${FC} --version
+            - pushd tests/fortomp
+            - if: target_platform == cross_target_platform and (x86_64 or aarch64 or ppc64le)
+              then: sh test_fort.sh
     about:
       summary: GNU Fortran Compiler (activation scripts)
       license: BSD-3-Clause
@@ -378,7 +380,7 @@ outputs:
       name: gcc_bootstrap_${{ cross_target_platform }}
       version: ${{ gcc_version }}
     build:
-      skip: default_skip
+      skip: default_skip or cross_target_platform in ("osx-64", "osx-arm64")
       always_include_files:
         - ${{ library_prefix }}bin/
         - ${{ library_prefix }}etc/

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -352,7 +352,7 @@ outputs:
           - if: cross_target_platform == "win-64"
             then: ucrt >=10.0.20348.0
     tests:
-      - if: linux and cross_target_platform not in ("osx-64", "osx-arm64"):
+      - if: linux and cross_target_platform not in ("osx-64", "osx-arm64")
         then:
           - files:
               recipe:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -354,22 +354,22 @@ outputs:
     tests:
       - if: linux and cross_target_platform not in ("osx-64", "osx-arm64"):
         then:
-          files:
-            recipe:
-              - tests/fortomp/*
-          requirements:
-            run:
-              - if: x86_64 or aarch64 or ppc64le
-                then: cmake >=3.11
-              - if: x86_64 or aarch64 or ppc64le
-                then: make
-              - if: cross_stdlib != "None"
-                then: ${{ cross_stdlib }}_${{ cross_target_platform }} ${{ cross_stdlib_version }}.*
-          script:
-            - ${FC} --version
-            - pushd tests/fortomp
-            - if: target_platform == cross_target_platform and (x86_64 or aarch64 or ppc64le)
-              then: sh test_fort.sh
+          - files:
+              recipe:
+                - tests/fortomp/*
+            requirements:
+              run:
+                - if: x86_64 or aarch64 or ppc64le
+                  then: cmake >=3.11
+                - if: x86_64 or aarch64 or ppc64le
+                  then: make
+                - if: cross_stdlib != "None"
+                  then: ${{ cross_stdlib }}_${{ cross_target_platform }} ${{ cross_stdlib_version }}.*
+            script:
+              - ${FC} --version
+              - pushd tests/fortomp
+              - if: target_platform == cross_target_platform and (x86_64 or aarch64 or ppc64le)
+                then: sh test_fort.sh
     about:
       summary: GNU Fortran Compiler (activation scripts)
       license: BSD-3-Clause


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
