### PR TITLE
Set CMake emulator in cross compiler activation

### DIFF
--- a/recipe/activate-gcc.sh
+++ b/recipe/activate-gcc.sh
@@ -198,7 +198,8 @@ unset _MESON_ARGS
 # shellcheck disable=SC2050 # templating will fix this error
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ] && [ "@CMAKE_SYSTEM_NAME@" = "Linux" ]; then
   _tc_activation \
-     "QEMU_LD_PREFIX,${QEMU_LD_PREFIX:-${CONDA_BUILD_SYSROOT}}"
+    "QEMU_LD_PREFIX,${QEMU_LD_PREFIX:-${CONDA_BUILD_SYSROOT}}" \
+    "CMAKE_CROSSCOMPILING_EMULATOR,${CMAKE_CROSSCOMPILING_EMULATOR:-${CROSSCOMPILING_EMULATOR:-}}"
 fi
 
 # shellcheck disable=SC2050 # templating will fix this error

--- a/recipe/deactivate-gcc.sh
+++ b/recipe/deactivate-gcc.sh
@@ -65,7 +65,7 @@ fi
 
 # shellcheck disable=SC2050 # templating will fix this error
 if [ "@CONDA_BUILD_CROSS_COMPILATION@" = "1" ] && [ "@CMAKE_SYSTEM_NAME@" = "Linux" ]; then
-  _tc_deactivation "QEMU_LD_PREFIX"
+  _tc_deactivation "QEMU_LD_PREFIX" "CMAKE_CROSSCOMPILING_EMULATOR"
 fi
 
 _tc_deactivation \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  build_num: 1
+  build_num: 2
   gcc_version: ${{ gcc_version | default("16.2.0") }}
   gcc_major: ${{ (gcc_version | split("."))[0] | int }}
   default_skip: ${{ (target_platform == "win-64" and cross_target_platform != "win-64") or cross_target_platform == "linux-s390x" or s390x or ((cross_target_platform in ("linux-riscv64", "osx-64", "osx-arm64") or osx) and gcc_major|int < 15) or (riscv64 and gcc_major|int < 15) or (riscv64 and cross_target_platform in ("osx-64", "osx-arm64")) }}


### PR DESCRIPTION
For cross-compilation to Linux, derive `CMAKE_CROSSCOMPILING_EMULATOR` from `CROSSCOMPILING_EMULATOR` in the compiler activation script.

This keeps the CMake-specific setting with the other generated cross-toolchain configuration, preserves an explicitly supplied CMake emulator, and restores the prior value on deactivation.